### PR TITLE
Add Promise Polyfill dependency (for tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,13 @@ env:
     - CXX=g++-4.8
 node_js: stable
 addons:
-  firefox: latest
   apt:
     sources:
-      - google-chrome
       - ubuntu-toolchain-r-test
     packages:
-      - google-chrome-stable
       - g++-4.8
   sauce_connect: true
 script:
-  - xvfb-run wct
   - wct -s 'default'
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
   sauce_connect: true
 script:
   - xvfb-run wct
-  - "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ]; then wct -s 'default'; fi"
+  - wct -s 'default'
 branches:
   only:
   - gh-pages

--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
     "web-component-tester": "Polymer/web-component-tester#^4.3.1"
   },
   "dependencies": {
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.22"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.22",
+    "promise-polyfill": "taylorhakes/promise-polyfill#^6.0.1"
   }
 }

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
+    <script type="../../promise-polyfill/promise.js"></script>
 
     <!-- Step 1: import the element to test -->
     <link rel="import" href="../dialog-el.html">

--- a/test/index.html
+++ b/test/index.html
@@ -12,6 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
+    <script type="../../promise-polyfill/promise.js"></script>
   </head>
   <body>
     <script>


### PR DESCRIPTION
Adds a dependency on `taylorhakes/promise-polyfill` to enable IE 11 testing.
