### PR TITLE
Remove will-change CSS style (temporary)

### DIFF
--- a/dialog-el.html
+++ b/dialog-el.html
@@ -22,7 +22,6 @@
       transform: scale(0.7);
       -webkit-transition: transform 0.3s, opacity 0.3s;
       transition: transform 0.3s, opacity 0.3s;
-      will-change: transform, opacity;
     }
 
 


### PR DESCRIPTION
The `will-change` property allows the browser to pre-optimize for animations. However, for some reason, this is causing the browser to not render the content clearly.
