### PR TITLE
Add a couple css variables to style the content

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,15 @@ document.body.appendChild(dialogEl);
   
 - `dialog-closed`
 
-  Fired whenever the dialog is closed.
+
+  
+## CSS Custom Properties
+
+Use these to override default styles
+
+Property Name | Description | Default Value
+-------------| --------------| -------------
+`--dialog-el-padding` | Used as the padding for the dialog | `15px`
+`--dialog-el-background` | Used for the `background` property of the dialog | `#FFFFFF`
+
+These defaults effectively wrap your provided local DOM in a 15px white border. Override them to change the appearance.  

--- a/dialog-el.html
+++ b/dialog-el.html
@@ -12,11 +12,11 @@
     }
     
     .content {
-      background: #fff;
+      background: var(--dialog-el-background, #fff);
       border-radius: 4px;
       box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.35), 0px 3px 2px 0px rgba(0,0,0,0.18);
       opacity: 0;
-      padding: 15px;
+      padding: var(--dialog-el-padding, 15px);
       position: relative;
       -webkit-transform: scale(0.7);
       transform: scale(0.7);

--- a/index.html
+++ b/index.html
@@ -219,8 +219,8 @@
 
       <p>If set the dialog will render as a fixed position modal instead of an absolute positioned div.</p>
     </li>
-  </ul>
-  
+  </ul> 
+
   <h2>Events</h2>
 
   <ul>
@@ -236,7 +236,33 @@
       <p>Fired whenever the dialog is closed.</p>
     </li>
   </ul>
+
   
+  <h2>CSS Custom Properties</h2>
+  <p>Use these to override default styles</p>
+  <table>
+    <thead>
+      <tr>
+        <td>Property Name</td>
+        <td>Description</td>
+        <td>Default Value</td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>--dialog-el-padding</code></td>
+        <td>Used as the padding for the dialog</td>
+        <td><code>15px</code></td>
+      </tr>
+      <tr>
+        <td><code>--dialog-el-background</code></td>
+        <td>Used for the <code>background</code> property of the dialog</td>
+        <td><code>#FFFFFF</code></td>
+      </tr>
+    </tbody>
+  </table>
+  
+  <p>These defaults effectively wrap your provided local DOM in a 15px white border. Override them to change the appearance.</p>
   <script src='assets/prism.js'></script>
 </body>
 </html>


### PR DESCRIPTION
background-color and padding are both helpful to avoid the appearance
of a 15px white border around dialog contents.

Where should these be documented? Let me know and I'm happy to add that.