### PR TITLE
Click Handler Refactor

### DIFF
--- a/dialog-el.html
+++ b/dialog-el.html
@@ -251,52 +251,6 @@
       if (focusableChildren[0]) focusableChildren[0].focus();
     }
 
-    // Content click handler
-    var handleClick = function() {
-      var _host;
-      return function(e) {
-        var host = _host || (function(el) {
-          var orig = el;
-          while(el.nodeType != 11) {
-            el = el.parentNode;
-          }
-          // Set up reference to host to avoid
-          // querying the DOM later
-          return (_host = el.host);
-        })(this);
-
-        // Find the index of the clicked dialog
-        var index = _dialogStack.indexOf(host);
-
-        // If there are dialogs on top of the clicked
-        // dialog loop through and close them (we assume
-        // that you intended to close all the other
-        // dialogs in this case)
-        if (_dialogStack.length > index + 1) {
-          _dialogStack.forEach(function(dialog, _index) {
-            if (_index <= index) return;
-            if (dialog.visible) dialog.close();
-          });
-        }
-        
-        /**
-         * By adding `dialog-submit` or `dialog-cancel` to a
-         * child of one of your components you can easily 
-         * close out the current dialog/modal. This will also
-         * customize the reason statement in the close event.
-         */
-        var dismissNodes = e.path.filter(function(el) {
-          return el.hasAttribute && (el.hasAttribute('dialog-cancel') || el.hasAttribute('dialog-submit'))
-        });
-        if (dismissNodes.length) {
-          host._closeAction = dismissNodes[0].hasAttribute('dialog-submit') ? 'submit' : 'cancel';
-          host.close();
-        }
-
-        if (e && e.stopPropagation) e.stopPropagation();
-      };
-    };
-
     /**
      * Executes querySelector on the current document
      */
@@ -508,6 +462,39 @@
       }.bind(this))
     }
 
+    proto._clickHandler = function(e) {
+      // Find the index of the clicked dialog
+      var index = _dialogStack.indexOf(this);
+
+      // If there are dialogs on top of the clicked
+      // dialog loop through and close them (we assume
+      // that you intended to close all the other
+      // dialogs in this case)
+      if (_dialogStack.length > index + 1) {
+        _dialogStack.forEach(function(dialog, _index) {
+          if (_index <= index) return;
+          if (dialog.visible) dialog.close();
+        });
+      }
+      
+      /**
+        * By adding `dialog-submit` or `dialog-cancel` to a
+        * child of one of your components you can easily 
+        * close out the current dialog/modal. This will also
+        * customize the reason statement in the close event.
+        */
+      var dismissNodes = e.path.filter(function(el) {
+        return el.hasAttribute && (el.hasAttribute('dialog-cancel') || el.hasAttribute('dialog-submit'))
+      });
+
+      if (dismissNodes.length) {
+        this._closeAction = dismissNodes[0].hasAttribute('dialog-submit') ? 'submit' : 'cancel';
+        this.close();
+      }
+
+      if (e && e.stopPropagation) e.stopPropagation();
+    };
+
     proto._getEventHandlers = function() {
       var array = []
 
@@ -515,7 +502,7 @@
       array.push({
         element: this._content,
         event: 'click',
-        handler: handleClick()
+        handler: this._clickHandler.bind(this)
       });
 
       array.push({

--- a/dialog-el.html
+++ b/dialog-el.html
@@ -433,8 +433,8 @@
       .then(function() {
         // Transition the elements out and resolve when the 
         // animation has completed
+        var event = 'transitionend';
         return new Promise(function(resolve, reject) {
-          var event = 'transitionend';
           var handler = function() {
             resolve();
             this._content.removeEventListener(event, handler);

--- a/dialog-el.html
+++ b/dialog-el.html
@@ -173,6 +173,7 @@
     // Master dialog stack, we use this to compute z-indexes as well as 
     // know which dialogs/modals to close on a click event in the DOM
     var _dialogStack = [];
+    var _globalWindowListener = false;
 
     var _isTouch = true;
     var _touchActive = false;
@@ -257,6 +258,12 @@
     var querySelector = function(selector) {
       var script = document._currentScript || document.currentScript;
       return script.ownerDocument.querySelector(selector);
+    };
+
+    var _closeAll = function() {
+      _dialogStack.forEach(function(dialog) {
+        if (dialog && dialog.close) dialog.close();
+      });
     };
 
     /** 
@@ -415,6 +422,13 @@
         _dialogStack = _dialogStack.filter(function(dialog) {
           return dialog !== this
         }.bind(this));
+
+        // Remove the global listener if the _dialogStack is empty
+        if (!_dialogStack.length) {
+          window.removeEventListener('click', _closeAll);
+          _globalWindowListener = false;
+        }
+
       }.bind(this))
       .then(function() {
         // Focus last active element and remove old reference
@@ -459,7 +473,7 @@
             action: this._closeAction
           }
         }));
-      }.bind(this))
+      }.bind(this));
     }
 
     proto._clickHandler = function(e) {
@@ -478,20 +492,26 @@
       }
       
       /**
-        * By adding `dialog-submit` or `dialog-cancel` to a
-        * child of one of your components you can easily 
-        * close out the current dialog/modal. This will also
-        * customize the reason statement in the close event.
-        */
+       * By adding `dialog-submit` or `dialog-cancel` to a
+       * child of one of your components you can easily 
+       * close out the current dialog/modal. This will also
+       * customize the reason statement in the close event.        
+       */
       var dismissNodes = e.path.filter(function(el) {
         return el.hasAttribute && (el.hasAttribute('dialog-cancel') || el.hasAttribute('dialog-submit'))
       });
 
+      /**
+       * Set the `_closeAction` property if `dialog-submit` or `dialog-cancel` is used to close the modal
+       */
       if (dismissNodes.length) {
         this._closeAction = dismissNodes[0].hasAttribute('dialog-submit') ? 'submit' : 'cancel';
         this.close();
       }
 
+      /**
+       * Don't propagate the event if we haven't already closed the modal
+       */
       if (e && e.stopPropagation) e.stopPropagation();
     };
 
@@ -503,13 +523,6 @@
         element: this._content,
         event: 'click',
         handler: this._clickHandler.bind(this)
-      });
-
-      array.push({
-        element: window,
-        event: 'click',
-        handler: this.close.bind(this),
-        delay: true
       });
 
       // A11y Event Handlers
@@ -555,6 +568,15 @@
           obj.element.addEventListener(obj.event, obj.handler);
         }
       }.bind(this));
+
+      // Window clicks should close all modals
+      // There is only one listener here
+      if (!_globalWindowListener) {
+        setTimeout(function() {
+          window.addEventListener('click', _closeAll);
+        }, 0);
+        _globalWindowListener = true;
+      }
     }
 
     // Detach all the needed event handlers

--- a/dialog-el.html
+++ b/dialog-el.html
@@ -260,12 +260,6 @@
       return script.ownerDocument.querySelector(selector);
     };
 
-    var _closeAll = function() {
-      _dialogStack.forEach(function(dialog) {
-        if (dialog && dialog.close) dialog.close();
-      });
-    };
-
     /** 
      * Reference the template tag in this current document when HTML imported
      * (Contains a fix for the `document.currentScript`/`document._currentScript`
@@ -276,7 +270,6 @@
     var modalTemplate = querySelector('#modal');
 
     var proto = Object.create(HTMLElement.prototype);
-
 
     /**
      * Getter/Setter for the `visible` status
@@ -349,7 +342,7 @@
 
     proto.detachedCallback = function() {
       if (this.visible) this.close();
-    }
+    };
 
     proto.show = function() {
       return Promise.resolve()
@@ -407,7 +400,7 @@
           bubbles: true,
         }));
       }.bind(this));
-    }
+    };
 
     proto.close = function() {
       return Promise.resolve()
@@ -425,7 +418,7 @@
 
         // Remove the global listener if the _dialogStack is empty
         if (!_dialogStack.length) {
-          window.removeEventListener('click', _closeAll);
+          window.removeEventListener('click', proto._closeAll);
           _globalWindowListener = false;
         }
 
@@ -474,7 +467,13 @@
           }
         }));
       }.bind(this));
-    }
+    };
+
+    proto._closeAll = function() {
+      _dialogStack.forEach(function(dialog) {
+        if (dialog && dialog.close) dialog.close();
+      });
+    };
 
     proto._clickHandler = function(e) {
       // Find the index of the clicked dialog
@@ -553,7 +552,7 @@
       });
 
       return array;
-    }
+    };
 
     // Properly attach all the needed event handlers
     proto._attachEventHandlers = function() {
@@ -573,17 +572,17 @@
       // There is only one listener here
       if (!_globalWindowListener) {
         setTimeout(function() {
-          window.addEventListener('click', _closeAll);
-        }, 0);
+          window.addEventListener('click', proto._closeAll);
+        }.bind(this), 0);
         _globalWindowListener = true;
       }
-    }
+    };
 
     // Detach all the needed event handlers
     proto._detachEventHandlers = function() {
       if (!Array.isArray(this.__handlers)) return;
       this.__handlers.forEach(function(obj) { obj.element.removeEventListener(obj.event, obj.handler) });
-    }
+    };
 
 
     document.registerElement('dialog-el', {

--- a/test/a11y.html
+++ b/test/a11y.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../promise-polyfill/promise.js"></script>
+
+    <!-- Step 1: import the element to test -->
+    <link rel="import" href="../dialog-el.html">
+  </head>
+  <body>
+
+    <!-- You can use the document as a place to set up your fixtures. -->
+    <test-fixture id="a11y">
+      <template>
+        <dialog-el modal>
+          <h1>Simple Dialog</h1>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+          quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+          cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+          proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </dialog-el>
+      </template>
+    </test-fixture>
+
+    <script>
+      describe('<dialog-el> A11y', function() {
+        /**
+         * Do a11y audit if native shadow DOM is supported
+         */
+        if (!window.ShadowDOMPolyfill) {
+          a11ySuite('a11y');
+        }
+      });
+    </script>
+
+  </body>
+</html>

--- a/test/click-handlers.html
+++ b/test/click-handlers.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../promise-polyfill/promise.js"></script>
+
+    <!-- Step 1: import the element to test -->
+    <link rel="import" href="../dialog-el.html">
+  </head>
+  <body>
+
+    <test-fixture id="simple-dialog">
+      <template>
+        <dialog-el>
+          <h1>Simple Dialog</h1>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+          quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+          cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+          proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </dialog-el>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="simple-modal">
+      <template>
+        <dialog-el modal>
+          <h1>Simple Modal</h1>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+          quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+          cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+          proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </dialog-el>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="nested-modal">
+      <template>
+        <dialog-el modal>
+          <h1>Simple Modal</h1>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+          quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+          cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+          proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <dialog-el>
+            <h2>Simple Dialog</h2>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Expedita numquam quibusdam harum? Perspiciatis harum a qui, numquam saepe dicta, magni esse doloremque ullam dolorum nisi, praesentium eius ipsa reiciendis aliquid!</p>
+          </dialog-el>
+        </dialog-el>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="nested-dialog">
+      <template>
+        <dialog-el>
+          <h1>Simple Dialog</h1>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+          quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+          cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+          proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          <dialog-el>
+            <h2>Simple Dialog</h2>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Expedita numquam quibusdam harum? Perspiciatis harum a qui, numquam saepe dicta, magni esse doloremque ullam dolorum nisi, praesentium eius ipsa reiciendis aliquid!</p>
+          </dialog-el>
+        </dialog-el>
+      </template>
+    </test-fixture>
+
+    <script>
+      describe('<dialog-el> Click Handlers', function() {
+        var dialog, modal, nestedDialog, nestedModal;
+        beforeEach(function() {
+          dialog = fixture('simple-dialog');
+          modal = fixture('simple-modal');
+          nestedModal = fixture('nested-modal');
+          nestedDialog = fixture('nested-modal');
+        });
+
+        it('should close all dialogs when window (not dialog content) is clicked', function(done) {
+          var _closeAll = sinon.stub(dialog.__proto__, '_closeAll');
+          dialog.show()
+            .then(function() {
+              document.body.click();
+            })
+            .then(function() {
+              expect(_closeAll.calledOnce).to.be.true;
+              _closeAll.restore();              
+              done();
+            });
+        });
+
+        it('`close all` should call `close` on dialogs when window is clicked', function(done) {
+          var close = sinon.stub(dialog, 'close');
+          dialog.show()
+            .then(function() {
+              document.body.click();
+            })
+            .then(function() {
+              expect(close.calledOnce).to.be.true;
+              close.restore();
+              done();
+            });
+        });
+
+        it('should close modal when overlay is clicked', function(done) {
+          var close = sinon.stub(modal, 'close');
+          modal.show()
+            .then(function() {
+              modal._overlay.click();
+            })
+            .then(function() {
+              expect(close.calledOnce).to.be.true;
+              close.restore();
+              done();
+            });
+        });
+
+        it('should close relevant stacked modals on sub-modal click', function(done) {
+          var inner = nestedModal.querySelector('dialog-el');
+          var close = sinon.stub(inner, 'close');
+
+          nestedModal.show()
+            .then(function() {
+              return inner.show();
+            })
+            .then(function() {
+              nestedModal._content.click();
+            })
+            .then(function() {
+              expect(close.calledOnce).to.be.true;
+              close.restore();
+              done();
+            });
+        });
+
+        it('should close all stacked dialogs on window click', function(done) {
+          var inner = nestedDialog.querySelector('dialog-el');
+          var close1 = sinon.stub(inner, 'close');
+          var close2 = sinon.stub(nestedDialog, 'close');
+
+          nestedDialog.show()
+            .then(function() {
+              return inner.show();
+            })
+            .then(function() {
+              document.body.click();
+            })
+            .then(function() {
+              expect(close1.calledOnce).to.be.true;
+              expect(close2.calledOnce).to.be.true;
+              close1.restore();
+              close2.restore();
+              done();
+            });
+        });
+
+      });
+    </script>
+
+  </body>
+</html>

--- a/test/happy-path.html
+++ b/test/happy-path.html
@@ -54,25 +54,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </dialog-el>
       </template>
     </test-fixture>
-    <test-fixture id="a11y">
-      <template>
-        <dialog-el>
-          <h1>Simple Dialog</h1>
-          <button dialog-cancel>Cancel</button>
-        </dialog-el>
-      </template>
-    </test-fixture>
 
     <script>
-      suite('<dialog-el>', function() {
+      describe('<dialog-el>', function() {
 
-        test('Should have expected API methods', function() {
+        it('Should have expected API methods', function() {
           var el = fixture('simple-dialog');
           expect(el.show).to.be.ok;
           expect(el.close).to.be.ok;
         });
 
-        test('Should fire bubbling `dialog-opened` event on `dialog.show()`', function(done) {
+        it('Should fire bubbling `dialog-opened` event on `dialog.show()`', function(done) {
           var el = fixture('simple-dialog');
           var handler = function() {
             document.removeEventListener('dialog-opened', handler);
@@ -82,7 +74,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           el.show();
         });
 
-        test('Should fire bubbling `dialog-closed` event on `dialog.close()`', function(done) {
+        it('Should fire bubbling `dialog-closed` event on `dialog.close()`', function(done) {
           var el = fixture('simple-dialog');
           var handler = function() {
             document.removeEventListener('dialog-closed', handler);
@@ -93,7 +85,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             .then(function() { el.close() });        
         });
 
-        test('Should close the dialog when a child with `dialog-submit` is clicked', function(done) {
+        it('Should close the dialog when a child with `dialog-submit` is clicked', function(done) {
           var el = fixture('simple-dialog-with-submit-button');
           
           var button = el.lastElementChild;
@@ -110,7 +102,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             });
         });
 
-        test('Should close the dialog when a child with `dialog-cancel` is clicked', function(done) {
+        it('Should close the dialog when a child with `dialog-cancel` is clicked', function(done) {
           var el = fixture('simple-dialog-with-cancel-button');
           
           var button = el.lastElementChild;
@@ -125,12 +117,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             .then(function() {
               button.click();
             });
-        });
-
-        test('Should pass an a11y audit (in native shadow DOM only)', function() {
-          if (!window.ShadowDOMPolyfill) {
-            a11ySuite('a11y');
-          }
         });
       });
     </script>

--- a/test/index.html
+++ b/test/index.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       // Load and run all tests (.html, .js):
       WCT.loadSuites([
-        'happy-path.html',
+        'primary-use-case.html',
         'click-handlers.html',
         'a11y.html'
       ]);

--- a/test/index.html
+++ b/test/index.html
@@ -18,7 +18,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       // Load and run all tests (.html, .js):
       WCT.loadSuites([
-        'basic-test.html'
+        'happy-path.html',
+        'click-handlers.html',
+        'a11y.html'
       ]);
     </script>
 

--- a/test/primary-use-case.html
+++ b/test/primary-use-case.html
@@ -57,63 +57,66 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
       describe('<dialog-el>', function() {
+        var dialog, submitDialog, cancelDialog;
+
+        beforeEach(function() {
+          dialog = fixture('simple-dialog');
+          submitDialog = fixture('simple-dialog-with-submit-button');
+          cancelDialog = fixture('simple-dialog-with-cancel-button');
+        });
+
 
         it('Should have expected API methods', function() {
-          var el = fixture('simple-dialog');
-          expect(el.show).to.be.ok;
-          expect(el.close).to.be.ok;
+          expect(dialog.show).to.be.ok;
+          expect(dialog.close).to.be.ok;
         });
 
         it('Should fire bubbling `dialog-opened` event on `dialog.show()`', function(done) {
-          var el = fixture('simple-dialog');
           var handler = function() {
-            document.removeEventListener('dialog-opened', handler);
+            dialog.removeEventListener('dialog-opened', handler);
             done();
           };
-          document.addEventListener('dialog-opened', handler);
-          el.show();
+          dialog.addEventListener('dialog-opened', handler);
+          dialog.show();
         });
 
         it('Should fire bubbling `dialog-closed` event on `dialog.close()`', function(done) {
-          var el = fixture('simple-dialog');
           var handler = function() {
-            document.removeEventListener('dialog-closed', handler);
+            dialog.removeEventListener('dialog-closed', handler);
             done();
           };
-          document.addEventListener('dialog-closed', handler);
-          el.show()
-            .then(function() { el.close() });        
+          dialog.addEventListener('dialog-closed', handler);
+          dialog.show()
+            .then(function() { 
+              dialog.close() 
+            });        
         });
 
         it('Should close the dialog when a child with `dialog-submit` is clicked', function(done) {
-          var el = fixture('simple-dialog-with-submit-button');
-          
-          var button = el.lastElementChild;
+          var button = submitDialog.lastElementChild;
 
           var handler = function(e) {
             expect(e.detail.action).to.equal('submit');
-            document.removeEventListener('dialog-closed', handler);
+            submitDialog.removeEventListener('dialog-closed', handler);
             done();
           };
-          document.addEventListener('dialog-closed', handler);
-          el.show()
+          submitDialog.addEventListener('dialog-closed', handler);
+          submitDialog.show()
             .then(function() {
               button.click();
             });
         });
 
         it('Should close the dialog when a child with `dialog-cancel` is clicked', function(done) {
-          var el = fixture('simple-dialog-with-cancel-button');
-          
-          var button = el.lastElementChild;
+          var button = cancelDialog.lastElementChild;
 
           var handler = function(e) {
             expect(e.detail.action).to.equal('cancel');
-            document.removeEventListener('dialog-closed', handler);
+            cancelDialog.removeEventListener('dialog-closed', handler);
             done();
           };
-          document.addEventListener('dialog-closed', handler);
-          el.show()
+          cancelDialog.addEventListener('dialog-closed', handler);
+          cancelDialog.show()
             .then(function() {
               button.click();
             });


### PR DESCRIPTION
Refactors the two major click handlers associated w/ this element.

### Changes

- Refactored `handleClick` function to be a member function on the prototype. Removes unneeded nasty while loop
- Refactored `window` listener to use a single listener that will clear **all** modals. Refactored the `proto.close` promise chain to, when it removes the dialog from the array, conditionally remove the global listener.

### Todo

- [x] Tests