### PR TITLE
Add auto-positioning functionality

### DIFF
--- a/dialog-el.html
+++ b/dialog-el.html
@@ -14,11 +14,14 @@
     }
 
     .content {
-      background: var(--dialog-el-background, #FFFFFF);
-      border-radius: var(--dialog-el-border-radius, 4px);
+      background: #FFFFFF;
+      background: var(--dialog-el-background);
+      border-radius: 4px;
+      border-radius: var(--dialog-el-border-radius);
       box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.35), 0px 3px 2px 0px rgba(0,0,0,0.18);
       opacity: 0;
-      padding: var(--dialog-el-padding, 15px);
+      padding: 15px;
+      padding: var(--dialog-el-padding);
       position: relative;
       -webkit-transform: scale(0.7);
       transform: scale(0.7);
@@ -74,7 +77,8 @@
       left: 50%;
       transform: rotate(45deg) translate3d(-50%,-5px,0);
       z-index: -1;
-      background-color: var(--dialog-el-background, #FFFFFF);
+      background-color: #FFFFFF;
+      background-color: var(--dialog-el-background);
       box-shadow: 0px 0px 0px 0px rgba(0,0,0,0.35), -1px -1px 1px 0px rgba(0,0,0,0.18);
     }
 

--- a/dialog-el.html
+++ b/dialog-el.html
@@ -3,7 +3,7 @@
     * {
       box-sizing: border-box;
     }
-    
+
     :host {
       position: absolute;
       display: inline-block;
@@ -15,13 +15,13 @@
 
     .content {
       background: #FFFFFF;
-      background: var(--dialog-el-background);
+      background: var(--dialog-el-background, #FFFFFF);
       border-radius: 4px;
-      border-radius: var(--dialog-el-border-radius);
+      border-radius: var(--dialog-el-border-radius, 4px);
       box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.35), 0px 3px 2px 0px rgba(0,0,0,0.18);
       opacity: 0;
       padding: 15px;
-      padding: var(--dialog-el-padding);
+      padding: var(--dialog-el-padding, 15px);
       position: relative;
       -webkit-transform: scale(0.7);
       transform: scale(0.7);
@@ -63,7 +63,7 @@
       opacity: 1;
     }
 
-    :host(:not([arrow-direction])) .pointer, 
+    :host(:not([arrow-direction])) .pointer,
     :host([arrow-direction][modal]) .pointer {
       display: none !important;
     }
@@ -78,7 +78,7 @@
       transform: rotate(45deg) translate3d(-50%,-5px,0);
       z-index: -1;
       background-color: #FFFFFF;
-      background-color: var(--dialog-el-background);
+      background-color: var(--dialog-el-background, #FFFFFF);
       box-shadow: 0px 0px 0px 0px rgba(0,0,0,0.35), -1px -1px 1px 0px rgba(0,0,0,0.18);
     }
 
@@ -122,7 +122,7 @@
 
 <script>
   (function(document, HTMLElement) {
-    // Master dialog stack, we use this to compute z-indexes as well as 
+    // Master dialog stack, we use this to compute z-indexes as well as
     // know which dialogs/modals to close on a click event in the DOM
     var _dialogStack = [];
     var _globalWindowListener = false;
@@ -186,7 +186,7 @@
       // If there are no focusable children in the dialog, prevent tabbing through the rest
       // of the document before clearing focus on the dialog
       if (!focusableChildren.length) return event.preventDefault();
-      
+
       var focusedItemIndex = focusableChildren.indexOf(activeElement);
 
       if (event.shiftKey && focusedItemIndex === 0) {
@@ -212,7 +212,7 @@
       return script.ownerDocument.querySelector(selector);
     };
 
-    /** 
+    /**
      * Reference the template tag in this current document when HTML imported
      * (Contains a fix for the `document.currentScript`/`document._currentScript`
      * https://github.com/webcomponents/webcomponentsjs#html-imports-documentcurrentscript-doesnt-work-as-expected-)
@@ -250,7 +250,7 @@
       }
     });
 
-    
+
     /**
      * Getter for the modal overlay
      */
@@ -285,7 +285,7 @@
       this.createShadowRoot().appendChild(style)
       this.shadowRoot.appendChild(template);
 
-      // If we have the full Shadow DOM polyfill and haven't instantiated 
+      // If we have the full Shadow DOM polyfill and haven't instantiated
       // an instance of this component once
       if (window.WebComponents && window.WebComponents.ShadowCSS && window.WebComponents.ShadowCSS.shimStyling) {
         window.WebComponents.ShadowCSS.shimStyling( this.shadowRoot, 'dialog-el' )
@@ -310,7 +310,7 @@
       .then(function() {
         this.hidden = false;
         this.removeAttribute('aria-hidden');
-        
+
         // Compute z-index for this dialog (based on stack index)
         this.style.zIndex = 1000 + _dialogStack.length - 1;
       }.bind(this))
@@ -383,7 +383,7 @@
         }
       }.bind(this))
       .then(function() {
-        // Transition the elements out and resolve when the 
+        // Transition the elements out and resolve when the
         // animation has completed
         var event = 'transitionend';
         return new Promise(function(resolve, reject) {
@@ -441,12 +441,12 @@
           if (dialog.visible) dialog.close();
         });
       }
-      
+
       /**
        * By adding `dialog-submit` or `dialog-cancel` to a
-       * child of one of your components you can easily 
+       * child of one of your components you can easily
        * close out the current dialog/modal. This will also
-       * customize the reason statement in the close event.        
+       * customize the reason statement in the close event.
        */
       var dismissNodes = e.path.filter(function(el) {
         return el.hasAttribute && (el.hasAttribute('dialog-cancel') || el.hasAttribute('dialog-submit'))

--- a/dialog-el.html
+++ b/dialog-el.html
@@ -203,23 +203,26 @@
     // Helper function for determining if the dialog needs to change direction.
     function autoPositionArrowDialog (dialog) {
       if (dialog.hasAttribute("arrow-direction")) {
-        var defaultDirection,
+        var arrowDirectionValue,
             minWidth,
             tempLeftPosition,
             tempTopPosition,
             pointer;
 
-        defaultDirection = dialog.attributes["arrow-direction"].value;
+        arrowDirectionValue = dialog.attributes["arrow-direction"].value;
 
         // Grab the min or fixed width of the dialog if there is one, or default to 100px.
         minWidth = parseFloat(dialog.style.width.replace("px", "") || dialog.style.minWidth.replace("px", "") || "100");
         tempLeftPosition = parseFloat(dialog.style.left.replace("px", ""));
         tempTopPosition = parseFloat(dialog.style.top.replace("px", ""));
         pointer = dialog.shadowRoot.querySelector(".pointer");
+        // Reset pointer to default CSS
+        pointer.style.left = "";
+        pointer.style.top = "";
 
-        switch (defaultDirection) {
+        switch (arrowDirectionValue) {
           case "left":
-            if (window.innerWidth - dialog.offsetLeft < minWidth) {
+            if (window.innerWidth - dialog.offsetLeft - 30 < minWidth) {
               dialog.attributes["arrow-direction"].value = "right";
               // if dialog doesn't fit with the "right" arrow, default to "top"
               if (dialog.offsetLeft - minWidth <= 0) {
@@ -245,7 +248,7 @@
             }
             break;
           case "right":
-            if (dialog.offsetLeft - minWidth <= 0) {
+            if (dialog.offsetLeft - 30 - minWidth <= 0) {
               dialog.attributes["arrow-direction"].value = "left";
               // if dialog doesn't fit with the "left" arrow, default to "top"
               if (window.innerWidth - dialog.offsetLeft < minWidth) {
@@ -271,7 +274,7 @@
             }
             break;
           case "bottom":
-            if (dialog.offsetTop - dialog.offsetHeight <= 0) {
+            if (dialog.offsetTop - dialog.offsetHeight - 30 <= 0) {
               dialog.attributes["arrow-direction"].value = "top";
               // Re-run function to get the right positioning
               autoPositionArrowDialog(dialog);
@@ -404,10 +407,10 @@
       if (this.visible) this.close();
     };
 
-    proto.show = function() {
+    proto.show = function(keepOpen) {
       return Promise.resolve()
       .then(function() {
-        if (this.visible) throw new Error('Tried to open a dialog that is already open', {
+        if (this.visible && !keepOpen) throw new Error('Tried to open a dialog that is already open', {
           element: this
         });
       }.bind(this))
@@ -428,35 +431,47 @@
         setFocusToFirstItem(this);
       }.bind(this))
       .then(function() {
-        // Compute arrow direction if needed
-        autoPositionArrowDialog(this);
+        if (this.hasAttribute("arrow-direction")) {
+          // If we've previously stored the original value, reset to that when opening a new dialog.
+          if (this.originalArrowDirection) {
+            this.attributes["arrow-direction"].value = this.originalArrowDirection;
+          } else {
+            // Store original arrow value for resetting next time
+            this.originalArrowDirection = this.attributes["arrow-direction"].value;
+          }
+          // Compute arrow direction if needed
+          autoPositionArrowDialog(this);
+        }
       }.bind(this))
       .then(function() {
-        // Transition the elements out and resolve when the
-        // animation has completed
-        var event = 'transitionend';
-        return new Promise(function(resolve, reject) {
-          var handler = function() {
-            resolve();
+        // Only show the transition on the original opening of the dialog.
+        if (!this.visible) {
+          // Transition the elements out and resolve when the
+          // animation has completed
+          var event = 'transitionend';
+          return new Promise(function(resolve, reject) {
+            var handler = function() {
+              resolve();
+              this._content.removeEventListener(event, handler);
+            }.bind(this);
+            this._content.addEventListener(event, handler);
+
+            // Delay the setting of visible property to allow nested
+            // elements time to display without being closed by the
+            // click handler. Also this allows element animations
+            // to occur.
+            setTimeout(function() { this.visible = true }.bind(this), 0);
+
+            // Set a backup handler call to ensure the modal opens
+            // even if for some reason the transition craps out
+            setTimeout(function() {
+              reject(handler)
+            }, 350);
+          }.bind(this)).catch(function(handler) {
+            console.warn('dialog "show" transition did not fire', this);
             this._content.removeEventListener(event, handler);
-          }.bind(this);
-          this._content.addEventListener(event, handler);
-
-          // Delay the setting of visible property to allow nested
-          // elements time to display without being closed by the
-          // click handler. Also this allows element animations
-          // to occur.
-          setTimeout(function() { this.visible = true }.bind(this), 0);
-
-          // Set a backup handler call to ensure the modal opens
-          // even if for some reason the transition craps out
-          setTimeout(function() {
-            reject(handler)
-          }, 350);
-        }.bind(this)).catch(function(handler) {
-          console.warn('dialog "show" transition did not fire', this);
-          this._content.removeEventListener(event, handler);
-        }.bind(this));
+          }.bind(this));
+        }
       }.bind(this))
       .then(function() {
         // Fire `dialog-opened` event

--- a/dialog-el.html
+++ b/dialog-el.html
@@ -200,6 +200,118 @@
       if (focusableChildren[0]) focusableChildren[0].focus();
     }
 
+    // Helper function for determining if the dialog needs to change direction.
+    function autoPositionArrowDialog (dialog) {
+      if (dialog.hasAttribute("arrow-direction")) {
+        var defaultDirection,
+            minWidth,
+            tempLeftPosition,
+            tempTopPosition,
+            pointer;
+
+        defaultDirection = dialog.attributes["arrow-direction"].value;
+
+        // Grab the min or fixed width of the dialog if there is one, or default to 100px.
+        minWidth = parseFloat(dialog.style.width.replace("px", "") || dialog.style.minWidth.replace("px", "") || "100");
+        tempLeftPosition = parseFloat(dialog.style.left.replace("px", ""));
+        tempTopPosition = parseFloat(dialog.style.top.replace("px", ""));
+        pointer = dialog.shadowRoot.querySelector(".pointer");
+
+        switch (defaultDirection) {
+          case "left":
+            if (window.innerWidth - dialog.offsetLeft < minWidth) {
+              dialog.attributes["arrow-direction"].value = "right";
+              // if dialog doesn't fit with the "right" arrow, default to "top"
+              if (dialog.offsetLeft - minWidth <= 0) {
+                dialog.attributes["arrow-direction"].value = "top";
+              }
+              // Re-run function to get the right positioning
+              autoPositionArrowDialog(dialog);
+              return;
+            } else {
+              // "left" is correct
+              // Create a buffer from the top and left
+              // coordinates so that the arrow lines up.
+              if (tempTopPosition - (dialog.offsetHeight / 2) < 0) {
+                //Reposition Arrow
+                pointer.style.top = tempTopPosition - 2 + "px";
+                pointer.style.left = "0px";
+                // Ensure that the dialog won't run off-screen
+                tempTopPosition = 0;
+              } else {
+                tempTopPosition -= (dialog.offsetHeight / 2);
+              }
+              tempLeftPosition += 30;
+            }
+            break;
+          case "right":
+            if (dialog.offsetLeft - minWidth <= 0) {
+              dialog.attributes["arrow-direction"].value = "left";
+              // if dialog doesn't fit with the "left" arrow, default to "top"
+              if (window.innerWidth - dialog.offsetLeft < minWidth) {
+                dialog.attributes["arrow-direction"].value = "top";
+              }
+              // Re-run function to get the right positioning
+              autoPositionArrowDialog(dialog);
+              return;
+            } else {
+              // "right" is correct
+              // Create a buffer from the top and left
+              // coordinates so that the arrow lines up.
+              if (tempTopPosition - (dialog.offsetHeight / 2) < 0) {
+                //Reposition Arrow
+                pointer.style.top = tempTopPosition - 2 + "px";
+                pointer.style.left = "100%";
+                // Ensure that the dialog won't run off-screen
+                tempTopPosition = 0;
+              } else {
+                tempTopPosition -= (dialog.offsetHeight / 2);
+              }
+              tempLeftPosition -= (dialog.offsetWidth + 30);
+            }
+            break;
+          case "bottom":
+            if (dialog.offsetTop - dialog.offsetHeight <= 0) {
+              dialog.attributes["arrow-direction"].value = "top";
+              // Re-run function to get the right positioning
+              autoPositionArrowDialog(dialog);
+              return;
+            }
+            // "bottom" is correct
+            // Create a buffer from the top and left
+            // coordinates so that the arrow lines up.
+            if (tempLeftPosition - (dialog.offsetWidth / 2) < 0) {
+              //Reposition Arrow
+              pointer.style.top = "100%";
+              pointer.style.left = tempLeftPosition - 7 + "px";
+              // Ensure that the dialog won't run off-screen
+              tempLeftPosition = 0;
+            } else {
+              tempLeftPosition -= (dialog.offsetWidth / 2);
+            }
+            tempTopPosition -= (dialog.offsetHeight + 30);
+            break;
+          case "top":
+            // "top" is default (because it's scrollable)
+            // Create a buffer from the top and left
+            // coordinates so that the arrow lines up.
+            if (tempLeftPosition - (dialog.offsetWidth / 2) < 0) {
+              //Reposition Arrow
+              pointer.style.top = "0px";
+              pointer.style.left = tempLeftPosition - 7 + "px";
+              // Ensure that the dialog won't run off-screen
+              tempLeftPosition = 0;
+            } else {
+              tempLeftPosition -= (dialog.offsetWidth / 2);
+            }
+            tempTopPosition += 30;
+            break;
+        }
+        dialog.style.left = tempLeftPosition + "px";
+        dialog.style.top = tempTopPosition + "px";
+      }
+    }
+
     /**
      * Executes querySelector on the current document
      */
@@ -316,7 +428,11 @@
         setFocusToFirstItem(this);
       }.bind(this))
       .then(function() {
-        // Transition the elements out and resolve when the 
+        // Compute arrow direction if needed
+        autoPositionArrowDialog(this);
+      }.bind(this))
+      .then(function() {
+        // Transition the elements out and resolve when the
         // animation has completed
         var event = 'transitionend';
         return new Promise(function(resolve, reject) {

--- a/dialog-el.html
+++ b/dialog-el.html
@@ -594,7 +594,7 @@
       /**
        * Don't propagate the event if we haven't already closed the modal
        */
-      if (e && e.stopPropagation) e.stopPropagation();
+      if (e && e.stopPropagation && e.target.tagName !== 'A') e.stopPropagation();
     };
 
     proto._getEventHandlers = function() {

--- a/dialog-el.html
+++ b/dialog-el.html
@@ -592,9 +592,10 @@
       }
 
       /**
-       * Don't propagate the event if we haven't already closed the modal
+       * Don't propagate the event if we haven't already closed the modal unless the target
+       * has an href so it can be caught by either the browser or a pushstate handler
        */
-      if (e && e.stopPropagation && e.target.tagName !== 'A') e.stopPropagation();
+      if (e && e.stopPropagation && !e.target.hasAttribute('href')) e.stopPropagation();
     };
 
     proto._getEventHandlers = function() {

--- a/dialog-el.html
+++ b/dialog-el.html
@@ -212,7 +212,7 @@
         arrowDirectionValue = dialog.attributes["arrow-direction"].value;
 
         // Grab the min or fixed width of the dialog if there is one, or default to 100px.
-        minWidth = parseFloat(dialog.style.width.replace("px", "") || dialog.style.minWidth.replace("px", "") || "100");
+        minWidth = parseFloat(dialog.style.width.replace("px", "") || dialog.style.minWidth.replace("px", "") || dialog.offsetWidth || "100");
         tempLeftPosition = parseFloat(dialog.style.left.replace("px", ""));
         tempTopPosition = parseFloat(dialog.style.top.replace("px", ""));
         pointer = dialog.shadowRoot.querySelector(".pointer");

--- a/index.html
+++ b/index.html
@@ -62,12 +62,13 @@
   <p>Click the following buttons to see different types of modals</p>
 
   <ul class='horizontal-ul'>
+    <li><button class='arrowDirectionDialog'>Arrow Direction Dialog</button></li>
     <li><button class='simpleDialog'>Simple Dialog</button></li>
     <li><button class='simpleModal'>Simple Modal</button></li>
     <li><button class='nestedDialog'>Nested Dialog</button></li>
     <li><button class='nestedModal'>Nested Modal</button></li>
     <li><button class='focustrapping'>Focus Trapping Modal</button></li>
-    <li><button class='arrowDirectionDialog'>Arrow Direction Dialog</button></li>
+    <li><button class='arrowDirectionDialog2'>Arrow Direction Dialog2</button></li>
   </ul>
 
 
@@ -119,19 +120,23 @@
   </dialog-el>
 
   <script>
-    var dialogs = ['simpleDialog', 'simpleModal', 'nestedDialog', 'nestedModal', 'nestedDialog-child', 'nestedModal-child', 'focustrapping', 'arrowDirectionDialog'];
+    var dialogs = ['simpleDialog', 'simpleModal', 'nestedDialog', 'nestedModal', 'nestedDialog-child', 'nestedModal-child', 'focustrapping', 'arrowDirectionDialog', 'arrowDirectionDialog2'];
     dialogs.forEach(function(selector) {
-      document.querySelector('.' + selector).addEventListener('click', function() {
+      document.querySelector('.' + selector).addEventListener('click', function(e) {
+        e.stopPropagation();
         // Reposition the arrow-direction dialog
-        if (selector === 'arrowDirectionDialog') {
+        if (selector.search('arrowDirectionDialog') >= 0) {
           var arrowDirectionDialog = document.querySelector('#arrowDirectionDialog');
-          arrowDirectionDialog.style.top =  document.querySelector('button.arrowDirectionDialog').offsetTop + "px";
-          arrowDirectionDialog.style.left = document.querySelector('button.arrowDirectionDialog').offsetLeft + "px";
+          arrowDirectionDialog.style.top =  document.querySelector('button.' + selector).offsetTop + "px";
+          arrowDirectionDialog.style.left = document.querySelector('button.' + selector).offsetLeft + "px";
           // The fixed width is to emulate person-card
           arrowDirectionDialog.style.width = "486px";
+          // Show the dialog
+          document.querySelector('#arrowDirectionDialog').show(true);
+        } else {
+          // Show the dialog
+          document.querySelector('#' + selector).show();
         }
-        // Show the dialog
-        document.querySelector('#' + selector).show();
       });
     });
   </script>

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
     <button dialog-submit>Save!</button>
   </dialog-el>
 
-  <dialog-el id='arrowDirectionDialog' arrow-direction='top'>
+  <dialog-el id='arrowDirectionDialog' arrow-direction='left'>
     <h1>Arrow Direction Dialog!</h1>
     <p>This dialog should have an arrow pointing left. Note that positioning is up to the containing element.</p>
   </dialog-el>
@@ -122,6 +122,15 @@
     var dialogs = ['simpleDialog', 'simpleModal', 'nestedDialog', 'nestedModal', 'nestedDialog-child', 'nestedModal-child', 'focustrapping', 'arrowDirectionDialog'];
     dialogs.forEach(function(selector) {
       document.querySelector('.' + selector).addEventListener('click', function() {
+        // Reposition the arrow-direction dialog
+        if (selector === 'arrowDirectionDialog') {
+          var arrowDirectionDialog = document.querySelector('#arrowDirectionDialog');
+          arrowDirectionDialog.style.top =  document.querySelector('button.arrowDirectionDialog').offsetTop + "px";
+          arrowDirectionDialog.style.left = document.querySelector('button.arrowDirectionDialog').offsetLeft + "px";
+          // The fixed width is to emulate person-card
+          arrowDirectionDialog.style.width = "486px";
+        }
+        // Show the dialog
         document.querySelector('#' + selector).show();
       });
     });


### PR DESCRIPTION
There are quite a few changes, so any questions or suggestions are welcome. It's been well tested so I'm pretty confident in it. I tried to make things fairly clear, but if they aren't, let me know.

Basically the rules for auto-positioning are:
- The dialog must have an `arrow-direction` attribute set with a value.
- The show function must be called every time the dialog needs to reopen or change position so that the logic for positioning will run (the transition event logic will only fire for the initial load).
- The dialog must be given `style.left` and `style.top` properties to determine where the arrow is supposed to point.