### PR TITLE
Refactor auto position so anchor and dialog don't have to have same offset parent.

### DIFF
--- a/dialog-el.html
+++ b/dialog-el.html
@@ -204,13 +204,32 @@
       if (focusableChildren[0]) focusableChildren[0].focus();
     }
 
-    /**
-     * Executes querySelector on the current document
-     */
     var querySelector = function(selector) {
       var script = document._currentScript || document.currentScript;
       return script.ownerDocument.querySelector(selector);
     };
+
+    /**
+     * Gets top and left coordinates relative to document.
+     * http://stackoverflow.com/questions/5598743/finding-elements-position-relative-to-the-document
+     */
+    function getCoords(elem) {
+      var box = elem.getBoundingClientRect();
+
+      var body = document.body;
+      var docEl = document.documentElement;
+
+      var scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
+      var scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
+
+      var clientTop = docEl.clientTop || body.clientTop || 0;
+      var clientLeft = docEl.clientLeft || body.clientLeft || 0;
+
+      var top  = box.top +  scrollTop - clientTop;
+      var left = box.left + scrollLeft - clientLeft;
+
+      return { top: Math.round(top), left: Math.round(left) };
+  }
 
     /**
      * Reference the template tag in this current document when HTML imported
@@ -304,9 +323,8 @@
     }
 
     proto.positionDialog = function(anchor) {
-      // If `anchor` is falsy OR the anchor and dialog don't share an
-      // offsetParent, early return
-      if (!anchor || anchor.offsetParent !== this.offsetParent) return;
+      // If `anchor` is falsy, early return
+      if (!anchor) return;
 
       var quadrant = 0;
       if (this.hasAttribute('arrow-direction')) {
@@ -318,28 +336,29 @@
         };
 
         quadrant = directionQuadrantMap[this.getAttribute('arrow-direction')];
-
+        
         var arrowSize = 22;
+        this._resetPosition();
+        var anchorCoords = getCoords(anchor);
 
         switch (quadrant) {
           case 0: 
-            this.style.top = anchor.offsetTop - this.offsetHeight - arrowSize + 'px';
-            this.style.left = anchor.offsetLeft + anchor.offsetWidth / 2 - this.offsetWidth / 2 + 'px';
+            this.style.top = anchorCoords.top - this.offsetHeight - arrowSize + 'px';
+            this.style.left = anchorCoords.left + anchor.offsetWidth / 2 - this.offsetWidth / 2 + 'px';
             break;
           case 1: 
-            this.style.top = anchor.offsetTop + anchor.offsetHeight / 2 - this.offsetHeight / 2 + 'px';
-            this.style.left = anchor.offsetLeft + anchor.offsetWidth + arrowSize + 'px';
+            this.style.top = anchorCoords.top + anchor.offsetHeight / 2 - this.offsetHeight / 2 + 'px';
+            this.style.left = anchorCoords.left + anchor.offsetWidth + arrowSize + 'px';
             break;
           case 2: 
-            this.style.top = anchor.offsetTop + anchor.offsetHeight / 2 - this.offsetHeight / 2 + 'px';
-            this.style.left = anchor.offsetLeft - this.offsetWidth - arrowSize + 'px';
+            this.style.top = anchorCoords.top + anchor.offsetHeight / 2 - this.offsetHeight / 2 + 'px';
+            this.style.left = anchorCoords.left - this.offsetWidth - arrowSize + 'px';
             break;
           case 3: 
-            this.style.top = anchor.offsetTop + anchor.offsetHeight + arrowSize + 'px';
-            this.style.left = anchor.offsetLeft + anchor.offsetWidth / 2 - this.offsetWidth / 2 + 'px';
+            this.style.top = anchorCoords.top + anchor.offsetHeight + arrowSize + 'px';
+            this.style.left = anchorCoords.left + anchor.offsetWidth / 2 - this.offsetWidth / 2 + 'px';
             break;
           default:
-            this._resetPosition();
             break;
         }
       } else {


### PR DESCRIPTION
Here's an idea for positioning the dialog according to the document `top` and `left` parameters. The custom `getCoords` function retrieves the element's position relative to the document, not the window like `getBoundClientRect()` or the offsetParent like `offsetLeft` and `offsetTop`. 